### PR TITLE
Fix for Lab 3 wrong CLI command in the 'resolving problems' section

### DIFF
--- a/Narzędzia Pracy Grupowej/Lab 3 (Wstęp do GIT)/lab3.md
+++ b/Narzędzia Pracy Grupowej/Lab 3 (Wstęp do GIT)/lab3.md
@@ -145,7 +145,7 @@ Git w ten sposób zaznacza konflikt w plikach. Żeby go rozwiązać należy zedy
 	1. `git status`
 	1. `git add README.md`
 	1. `git commit -m 'twoja_wiadomość'` opcjonalnie `git commit -a` by Git dodał informację o ręcznym rozwiązaniu konfliktu.
-	1. `git push`
+	1. `git pull`
 7. Sprawdź wersję plików na serwerze.
 
 **Zadanie 7** 


### PR DESCRIPTION
This commit fixes the problem with Lab 3 wrong CLI command: `push` does not allow for a conflict occurence, it immediately throws an exception due to a discrepancy between the local files & files on the server; `git push --force` would overwrite the files with local branch history ignoring the differences.
Therefore, the solution should be `git pull`.